### PR TITLE
Testing out a new GitHub link with NESified icon

### DIFF
--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -299,7 +299,12 @@ const Home = () => {
                 </Box>
                 <Flex align='center' justify='center' textAlign='center'>
                     <Box fontSize={responsiveFontSizes} m={[2, 4, 6, 8]} whiteSpace='pre-wrap' wordBreak='break-all'>
-                        See the code: <Link isExternal href='https://github.com/solipsis/ethsplainer'>https://github.com/solipsis/ethsplainer</Link>
+                        <Link isExternal href='https://github.com/solipsis/ethsplainer'><i class='nes-icon github is-medium'></i>
+                            <br/>
+                        </Link>
+                            See the code on <Link isExternal href='https://github.com/solipsis/ethsplainer'>
+                            GitHub
+                        </Link>
                     </Box>
                 </Flex>
             </Container>


### PR DESCRIPTION
This branch revises the bottom text link into a NESified Github icon. Since it's an NES react component, it only allows sizing of is-small, is-medium, and is-large. This could look weird on some smaller/larger displays. @peterhendrick may have a fix or way to resize similar to the way Chakra does it. 

Use this or don't, I don't care. :)

*Preview Image:*
![newicon-preview](https://user-images.githubusercontent.com/6909088/76054447-e8ac6280-5f2d-11ea-94f3-7d791a8f03d1.png)
